### PR TITLE
add expect_stdout tests from uglify-js without code changes

### DIFF
--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -2093,3 +2093,90 @@ issue_2846: {
     }
     expect_stdout: "0"
 }
+
+issue_805_1: {
+    options = {
+        inline: true,
+        passes: 2,
+        pure_getters: "strict",
+        reduce_vars: true,
+        sequences: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        (function(a) {
+            var unused = function() {};
+            unused.prototype[a()] = 42;
+            (unused.prototype.bar = function() {
+                console.log("bar");
+            })();
+            return unused;
+        })(function() {
+            console.log("foo");
+            return "foo";
+        });
+    }
+    expect_stdout: [
+        "foo",
+        "bar",
+    ]
+}
+
+issue_805_2: {
+    options = {
+        inline: true,
+        passes: 2,
+        pure_getters: "strict",
+        reduce_vars: true,
+        sequences: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        (function(a) {
+            function unused() {}
+            unused.prototype[a()] = 42;
+            (unused.prototype.bar = function() {
+                console.log("bar");
+            })();
+            return unused;
+        })(function() {
+            console.log("foo");
+            return "foo";
+        });
+    }
+    expect_stdout: [
+        "foo",
+        "bar",
+    ]
+}
+
+issue_2995: {
+    options = {
+        pure_getters: "strict",
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        function f(a) {
+            var b;
+            a.b = b = function() {};
+            b.c = "PASS";
+        }
+        var o = {};
+        f(o);
+        console.log(o.b.c);
+    }
+    expect: {
+        function f(a) {
+            var b;
+            a.b = b = function() {};
+            b.c = "PASS";
+        }
+        var o = {};
+        f(o);
+        console.log(o.b.c);
+    }
+    expect_stdout: "PASS"
+}

--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -1638,3 +1638,25 @@ optional_expect_when_expect_stdout_present: {
     }
     expect_stdout: "2"
 }
+
+issue_2968: {
+    options = {
+        collapse_vars: true,
+        evaluate: true,
+        inline: true,
+        passes: 2,
+        reduce_vars: true,
+        unused: true,
+    }
+    input: {
+        var c = "FAIL";
+        (function() {
+            (function(a, b) {
+                a <<= 0;
+                a && (a[(c = "PASS", 0 >>> (b += 1))] = 0);
+            })(42, -42);
+        })();
+        console.log(c);
+    }
+    expect_stdout: "PASS"
+}

--- a/test/compress/evaluate.js
+++ b/test/compress/evaluate.js
@@ -1628,3 +1628,13 @@ issue_2926_2: {
     }
     expect_stdout: "function"
 }
+
+optional_expect_when_expect_stdout_present: {
+    options = {
+        evaluate: true,
+    }
+    input: {
+        console.log(5 % 3);
+    }
+    expect_stdout: "2"
+}

--- a/test/compress/functions.js
+++ b/test/compress/functions.js
@@ -2432,6 +2432,63 @@ issue_3018: {
     expect_stdout: "PASS"
 }
 
+issue_3054: {
+    options = {
+        booleans: true,
+        collapse_vars: true,
+        inline: 1,
+        reduce_vars: true,
+        toplevel: true,
+    }
+    input: {
+        "use strict";
+        function f() {
+            return { a: true };
+        }
+        console.log(function(b) {
+            b = false;
+            return f();
+        }().a, f.call().a);
+    }
+    expect_stdout: "true true"
+}
+
+issue_3076: {
+    options = {
+        dead_code: true,
+        inline: true,
+        sequences: true,
+        unused: true,
+    }
+    input: {
+        var c = "PASS";
+        (function(b) {
+            var n = 2;
+            while (--b + function() {
+                e && (c = "FAIL");
+                e = 5;
+                return 1;
+                try {
+                    var a = 5;
+                } catch (e) {
+                    var e;
+                }
+            }().toString() && --n > 0);
+        })(2);
+        console.log(c);
+    }
+    expect: {
+        var c = "PASS";
+        (function(b) {
+            var n = 2;
+            while (--b + (e = void 0, e && (c = "FAIL"), e = 5, 1).toString() && --n > 0);
+            var e;
+        })(2),
+        console.log(c);
+    }
+    expect_stdout: "PASS"
+}
+
 issue_3125: {
     options = {
         inline: true,

--- a/test/compress/hoist_props.js
+++ b/test/compress/hoist_props.js
@@ -978,3 +978,108 @@ issue_3046: {
     }
     expect_stdout: "1"
 }
+
+issue_3071_1: {
+    options = {
+        evaluate: true,
+        inline: true,
+        join_vars: true,
+        hoist_props: true,
+        passes: 3,
+        reduce_vars: true,
+        sequences: true,
+        side_effects: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        (function() {
+            var obj = {};
+            obj.one = 1;
+            obj.two = 2;
+            console.log(obj.one);
+        })();
+    }
+    expect_stdout: "1"
+}
+
+issue_3071_2: {
+    options = {
+        evaluate: true,
+        inline: true,
+        join_vars: true,
+        hoist_props: true,
+        passes: 3,
+        reduce_vars: true,
+        sequences: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        (function() {
+            obj = {};
+            obj.one = 1;
+            obj.two = 2;
+            console.log(obj.one);
+            var obj;
+        })();
+    }
+    expect_stdout: "1"
+}
+
+issue_3071_2_toplevel: {
+    options = {
+        evaluate: true,
+        inline: true,
+        join_vars: true,
+        hoist_props: true,
+        passes: 3,
+        reduce_vars: true,
+        sequences: true,
+        side_effects: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        (function() {
+            obj = {};
+            obj.one = 1;
+            obj.two = 2;
+            console.log(obj.one);
+            var obj;
+        })();
+    }
+    expect_stdout: "1"
+}
+
+issue_3071_3: {
+    options = {
+        hoist_props: true,
+        reduce_vars: true,
+    }
+    input: {
+        var c = 0;
+        (function(a, b) {
+            (function f(o) {
+                var n = 2;
+                while (--b + (o = {
+                    p: c++,
+                }) && --n > 0);
+            })();
+        })();
+        console.log(c);
+    }
+    expect: {
+        var c = 0;
+        (function(a, b) {
+            (function f(o) {
+                var n = 2;
+                while (--b + (o = {
+                    p: c++,
+                }) && --n > 0);
+            })();
+        })();
+        console.log(c);
+    }
+    expect_stdout: "2"
+}

--- a/test/compress/issue-1704.js
+++ b/test/compress/issue-1704.js
@@ -345,3 +345,93 @@ mangle_catch_redef_2_ie8_toplevel: {
     expect_exact: 'try{throw"FAIL1"}catch(o){var o="FAIL2"}console.log(o);'
     expect_stdout: "undefined"
 }
+
+mangle_catch_redef_3: {
+    mangle = {
+        ie8: false,
+        toplevel: false,
+    }
+    input: {
+        var o = "PASS";
+        try {
+            throw 0;
+        } catch (o) {
+            (function() {
+                function f() {
+                    o = "FAIL";
+                }
+                f(), f();
+            })();
+        }
+        console.log(o);
+    }
+    expect_exact: 'var o="PASS";try{throw 0}catch(o){(function(){function c(){o="FAIL"}c(),c()})()}console.log(o);'
+    expect_stdout: "PASS"
+}
+
+mangle_catch_redef_3_toplevel: {
+    mangle = {
+        ie8: false,
+        toplevel: true,
+    }
+    input: {
+        var o = "PASS";
+        try {
+            throw 0;
+        } catch (o) {
+            (function() {
+                function f() {
+                    o = "FAIL";
+                }
+                f(), f();
+            })();
+        }
+        console.log(o);
+    }
+    expect_stdout: "PASS"
+}
+
+mangle_catch_redef_ie8_3: {
+    mangle = {
+        ie8: true,
+        toplevel: false,
+    }
+    input: {
+        var o = "PASS";
+        try {
+            throw 0;
+        } catch (o) {
+            (function() {
+                function f() {
+                    o = "FAIL";
+                }
+                f(), f();
+            })();
+        }
+        console.log(o);
+    }
+    expect_exact: 'var o="PASS";try{throw 0}catch(o){(function(){function c(){o="FAIL"}c(),c()})()}console.log(o);'
+    expect_stdout: "PASS"
+}
+
+mangle_catch_redef_3_ie8_toplevel: {
+    mangle = {
+        ie8: true,
+        toplevel: true,
+    }
+    input: {
+        var o = "PASS";
+        try {
+            throw 0;
+        } catch (o) {
+            (function() {
+                function f() {
+                    o = "FAIL";
+                }
+                f(), f();
+            })();
+        }
+        console.log(o);
+    }
+    expect_stdout: "PASS"
+}

--- a/test/compress/issue-973.js
+++ b/test/compress/issue-973.js
@@ -97,3 +97,32 @@ this_binding_side_effects: {
         }());
     }
 }
+
+this_binding_sequences: {
+    options = {
+        sequences: true,
+        side_effects: true,
+    }
+    input: {
+        console.log(typeof function() {
+            return eval("this");
+        }());
+        console.log(typeof function() {
+            "use strict";
+            return eval("this");
+        }());
+        console.log(typeof function() {
+            return (0, eval)("this");
+        }());
+        console.log(typeof function() {
+            "use strict";
+            return (0, eval)("this");
+        }());
+    }
+    expect_stdout: [
+        "object",
+        "undefined",
+        "object",
+        "object",
+    ]
+}

--- a/test/compress/loops.js
+++ b/test/compress/loops.js
@@ -715,3 +715,17 @@ issue_2740_8: {
     expect_stdout: "9 0"
     node_version: ">=6"
 }
+
+issue_2904: {
+    options = {
+        join_vars: true,
+        loops: true,
+    }
+    input: {
+        var a = 1;
+        do {
+            console.log(a);
+        } while (--a);
+    }
+    expect_stdout: "1"
+}

--- a/test/compress/properties.js
+++ b/test/compress/properties.js
@@ -1485,6 +1485,27 @@ join_object_assignments_3: {
     expect_stdout: "PASS"
 }
 
+join_object_assignments_4: {
+    options = {
+        join_vars: true,
+        sequences: true,
+    }
+    input: {
+        var o;
+        console.log(o);
+        o = {};
+        o.a = "foo";
+        console.log(o.b);
+        o.b = "bar";
+        console.log(o.a);
+    }
+    expect_stdout: [
+        "undefined",
+        "undefined",
+        "foo",
+    ]
+}
+
 join_object_assignments_return_1: {
     options = {
         join_vars: true,

--- a/test/compress/pure_getters.js
+++ b/test/compress/pure_getters.js
@@ -954,3 +954,286 @@ issue_2938_4: {
     }
     expect_stdout: "PASS"
 }
+
+collapse_vars_1_true: {
+    options = {
+        collapse_vars: true,
+        pure_getters: true,
+        unused: true,
+    }
+    input: {
+        function f(a, b) {
+            for (;;) {
+                var c = a.g();
+                var d = b.p;
+                if (c || d) break;
+            }
+        }
+    }
+    expect: {
+        function f(a, b) {
+            for (;;) {
+                if (a.g() || b.p) break;
+            }
+        }
+    }
+}
+
+collapse_vars_1_false: {
+    options = {
+        collapse_vars: true,
+        pure_getters: false,
+        unused: true,
+    }
+    input: {
+        function f(a, b) {
+            for (;;) {
+                var c = a.g();
+                var d = b.p;
+                if (c || d) break;
+            }
+        }
+    }
+    expect: {
+        function f(a, b) {
+            for (;;) {
+                var c = a.g();
+                var d = b.p;
+                if (c || d) break;
+            }
+        }
+    }
+}
+
+collapse_vars_1_strict: {
+    options = {
+        collapse_vars: true,
+        pure_getters: "strict",
+        unused: true,
+    }
+    input: {
+        function f(a, b) {
+            for (;;) {
+                var c = a.g();
+                var d = b.p;
+                if (c || d) break;
+            }
+        }
+    }
+    expect: {
+        function f(a, b) {
+            for (;;) {
+                var c = a.g();
+                var d = b.p;
+                if (c || d) break;
+            }
+        }
+    }
+}
+
+collapse_vars_2_true: {
+    options = {
+        collapse_vars: true,
+        pure_getters: true,
+        reduce_vars: true,
+    }
+    input: {
+        function f() {
+            function g() {}
+            g.a = function() {};
+            g.b = g.a;
+            return g;
+        }
+    }
+    expect: {
+        function f() {
+            function g() {}
+            g.b = g.a = function() {};
+            return g;
+        }
+    }
+}
+
+collapse_vars_2_false: {
+    options = {
+        collapse_vars: true,
+        pure_getters: false,
+        reduce_vars: true,
+    }
+    input: {
+        function f() {
+            function g() {}
+            g.a = function() {};
+            g.b = g.a;
+            return g;
+        }
+    }
+    expect: {
+        function f() {
+            function g() {}
+            g.a = function() {};
+            g.b = g.a;
+            return g;
+        }
+    }
+}
+
+collapse_vars_2_strict: {
+    options = {
+        collapse_vars: true,
+        pure_getters: "strict",
+        reduce_vars: true,
+    }
+    input: {
+        function f() {
+            function g() {}
+            g.a = function() {};
+            g.b = g.a;
+            return g;
+        }
+    }
+    expect: {
+        function f() {
+            function g() {}
+            g.a = function() {};
+            g.b = g.a;
+            return g;
+        }
+    }
+}
+
+collapse_rhs_true: {
+    options = {
+        collapse_vars: true,
+        pure_getters: true,
+    }
+    input: {
+        console.log((42..length = "PASS", "PASS"));
+        console.log(("foo".length = "PASS", "PASS"));
+        console.log((false.length = "PASS", "PASS"));
+        console.log((function() {}.length = "PASS", "PASS"));
+        console.log(({
+            get length() {
+                return "FAIL";
+            }
+        }.length = "PASS", "PASS"));
+    }
+    expect_stdout: [
+        "PASS",
+        "PASS",
+        "PASS",
+        "PASS",
+        "PASS",
+    ]
+}
+
+collapse_rhs_false: {
+    options = {
+        collapse_vars: true,
+        pure_getters: false,
+    }
+    input: {
+        console.log((42..length = "PASS", "PASS"));
+        console.log(("foo".length = "PASS", "PASS"));
+        console.log((false.length = "PASS", "PASS"));
+        console.log((function() {}.length = "PASS", "PASS"));
+        console.log(({
+            get length() {
+                return "FAIL";
+            }
+        }.length = "PASS", "PASS"));
+    }
+    expect_stdout: [
+        "PASS",
+        "PASS",
+        "PASS",
+        "PASS",
+        "PASS",
+    ]
+}
+
+collapse_rhs_strict: {
+    options = {
+        collapse_vars: true,
+        pure_getters: "strict",
+    }
+    input: {
+        console.log((42..length = "PASS", "PASS"));
+        console.log(("foo".length = "PASS", "PASS"));
+        console.log((false.length = "PASS", "PASS"));
+        console.log((function() {}.length = "PASS", "PASS"));
+        console.log(({
+            get length() {
+                return "FAIL";
+            }
+        }.length = "PASS", "PASS"));
+    }
+    expect_stdout: [
+        "PASS",
+        "PASS",
+        "PASS",
+        "PASS",
+        "PASS",
+    ]
+}
+
+collapse_rhs_setter: {
+    options = {
+        collapse_vars: true,
+        pure_getters: "strict",
+    }
+    input: {
+        try {
+            console.log(({
+                set length(v) {
+                    throw "PASS";
+                }
+            }.length = "FAIL", "FAIL"));
+        } catch (e) {
+            console.log(e);
+        }
+    }
+    expect_stdout: "PASS"
+}
+
+collapse_rhs_call: {
+    options = {
+        collapse_vars: true,
+        passes: 2,
+        pure_getters: "strict",
+        reduce_vars: true,
+        toplevel: true,
+        unused: true,
+    }
+    input: {
+        var o = {};
+        function f() {
+            console.log("PASS");
+        }
+        o.f = f;
+        f();
+    }
+    expect_stdout: "PASS"
+}
+
+collapse_rhs_lhs: {
+    options = {
+        collapse_vars: true,
+        pure_getters: true,
+    }
+    input: {
+        function f(a, b) {
+            a.b = b, b += 2;
+            console.log(a.b, b);
+        }
+        f({}, 1);
+    }
+    expect: {
+        function f(a, b) {
+            a.b = b, b += 2;
+            console.log(a.b, b);
+        }
+        f({}, 1);
+    }
+    expect_stdout: "1 3"
+}

--- a/test/compress/reduce_vars.js
+++ b/test/compress/reduce_vars.js
@@ -6387,3 +6387,360 @@ issue_3068_2: {
     }
     expect_stdout: true
 }
+
+issue_3110_1: {
+    options = {
+        conditionals: true,
+        evaluate: true,
+        inline: true,
+        passes: 3,
+        properties: true,
+        reduce_vars: true,
+        sequences: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        (function() {
+            function foo() {
+                return isDev ? "foo" : "bar";
+            }
+            var isDev = true;
+            var obj = {
+                foo: foo
+            };
+            console.log(foo());
+            console.log(obj.foo());
+        })();
+    }
+    expect_stdout: [
+        "foo",
+        "foo",
+    ]
+}
+
+issue_3110_2: {
+    options = {
+        conditionals: true,
+        evaluate: true,
+        inline: true,
+        passes: 4,
+        properties: true,
+        reduce_vars: true,
+        sequences: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        (function() {
+            function foo() {
+                return isDev ? "foo" : "bar";
+            }
+            var isDev = true;
+            console.log(foo());
+            var obj = {
+                foo: foo
+            };
+            console.log(obj.foo());
+        })();
+    }
+    expect_stdout: [
+        "foo",
+        "foo",
+    ]
+}
+
+issue_3110_3: {
+    options = {
+        conditionals: true,
+        evaluate: true,
+        inline: true,
+        properties: true,
+        reduce_vars: true,
+        sequences: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        (function() {
+            function foo() {
+                return isDev ? "foo" : "bar";
+            }
+            console.log(foo());
+            var isDev = true;
+            var obj = {
+                foo: foo
+            };
+            console.log(obj.foo());
+        })();
+    }
+    expect: {
+        (function() {
+            function foo() {
+                return isDev ? "foo" : "bar";
+            }
+            console.log(foo());
+            var isDev = true;
+            var obj = {
+                foo: foo
+            };
+            console.log(obj.foo());
+        })();
+    }
+    expect_stdout: [
+        "bar",
+        "foo",
+    ]
+}
+
+issue_3113_1: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+    }
+    input: {
+        var c = 0;
+        (function() {
+            function f() {
+                while (g());
+            }
+            var a = f();
+            function g() {
+                a && a[c++];
+            }
+            g(a = 1);
+        })();
+        console.log(c);
+    }
+    expect: {
+        var c = 0;
+        (function() {
+            function f() {
+                while (g());
+            }
+            var a = f();
+            function g() {
+                a && a[c++];
+            }
+            g(a = 1);
+        })();
+        console.log(c);
+    }
+    expect_stdout: "1"
+}
+
+issue_3113_2: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+    }
+    input: {
+        var c = 0;
+        (function() {
+            function f() {
+                while (g());
+            }
+            var a = f();
+            function g() {
+                a && a[c++];
+            }
+            a = 1;
+            g();
+        })();
+        console.log(c);
+    }
+    expect: {
+        var c = 0;
+        (function() {
+            function f() {
+                while (g());
+            }
+            var a = f();
+            function g() {
+                a && a[c++];
+            }
+            a = 1;
+            g();
+        })();
+        console.log(c);
+    }
+    expect_stdout: "1"
+}
+
+issue_3113_3: {
+    options = {
+        evaluate: true,
+        inline: true,
+        passes: 2,
+        pure_getters: "strict",
+        reduce_vars: true,
+        side_effects: true,
+        unused: true,
+    }
+    input: {
+        var c = 0;
+        (function() {
+            function f() {
+                while (g());
+            }
+            var a;
+            function g() {
+                a && a[c++];
+            }
+            g(a = 1);
+        })();
+        console.log(c);
+    }
+    expect_stdout: "1"
+}
+
+issue_3113_4: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        toplevel: true,
+    }
+    input: {
+        var a = 0, b = 0;
+        function f() {
+            b += a;
+        }
+        f(f(), ++a);
+        console.log(a, b);
+    }
+    expect: {
+        var a = 0, b = 0;
+        function f() {
+            b += a;
+        }
+        f(f(), ++a);
+        console.log(a, b);
+    }
+    expect_stdout: "1 1"
+}
+
+issue_3113_5: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+        toplevel: true,
+    }
+    input: {
+        function f() {
+            console.log(a);
+        }
+        function g() {
+            f();
+        }
+        while (g());
+        var a = 1;
+        f();
+    }
+    expect: {
+        function f() {
+            console.log(a);
+        }
+        function g() {
+            f();
+        }
+        while (g());
+        var a = 1;
+        f();
+    }
+    expect_stdout: [
+        "undefined",
+        "1",
+    ]
+}
+
+conditional_nested_1: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+    }
+    input: {
+        var a = 1, b = 0;
+        (function f(c) {
+            function g() {
+                c && (c.a = 0);
+                c && (c.a = 0);
+                c && (c[b++] *= 0);
+            }
+            g(a-- && f(g(c = 42)));
+        })();
+        console.log(b);
+    }
+    expect: {
+        var a = 1, b = 0;
+        (function f(c) {
+            function g() {
+                c && (c.a = 0);
+                c && (c.a = 0);
+                c && (c[b++] *= 0);
+            }
+            g(a-- && f(g(c = 42)));
+        })();
+        console.log(b);
+    }
+    expect_stdout: "2"
+}
+
+conditional_nested_2: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+    }
+    input: {
+        var c = 0;
+        (function(a) {
+            function f() {
+                a && c++;
+            }
+            f(!c && f(), a = 1);
+        })();
+        console.log(c);
+    }
+    expect: {
+        var c = 0;
+        (function(a) {
+            function f() {
+                a && c++;
+            }
+            f(!c && f(), a = 1);
+        })();
+        console.log(c);
+    }
+    expect_stdout: "1"
+}
+
+conditional_nested_3: {
+    options = {
+        evaluate: true,
+        reduce_vars: true,
+    }
+    input: {
+        var n = 2, c = 0;
+        (function f(a) {
+            0 < n-- && g(a = 1);
+            function g() {
+                a && c++;
+            }
+            g();
+            0 < n-- && f();
+        })();
+        console.log(c);
+    }
+    expect: {
+        var n = 2, c = 0;
+        (function f(a) {
+            0 < n-- && g(a = 1);
+            function g() {
+                a && c++;
+            }
+            g();
+            0 < n-- && f();
+        })();
+        console.log(c);
+    }
+    expect_stdout: "2"
+}

--- a/test/compress/sequences.js
+++ b/test/compress/sequences.js
@@ -901,3 +901,38 @@ forin: {
     }
     expect_stdout: "PASS"
 }
+
+call: {
+    options = {
+        sequences: true,
+    }
+    input: {
+        var a = function() {
+            return this;
+        }();
+        function b() {
+            console.log("foo");
+        }
+        b.c = function() {
+            console.log(this === b ? "bar" : "baz");
+        };
+        (a, b)();
+        (a, b.c)();
+        (a, function() {
+            console.log(this === a);
+        })();
+        new (a, b)();
+        new (a, b.c)();
+        new (a, function() {
+            console.log(this === a);
+        })();
+    }
+    expect_stdout: [
+        "foo",
+        "baz",
+        "true",
+        "foo",
+        "baz",
+        "false",
+    ]
+}

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -160,7 +160,10 @@ function run_compress_tests() {
                 }
             }
             output = make_code(output, output_options);
-            if (expect != output) {
+            if (test.expect_stdout && typeof expect == "undefined") {
+                // Do not verify generated `output` against `expect` or `expect_exact`.
+                // Rely on the pending `expect_stdout` check below.
+            } else if (expect != output) {
                 log("!!! failed\n---INPUT---\n{input}\n---OUTPUT---\n{output}\n---EXPECTED---\n{expected}\n\n", {
                     input: input_formatted,
                     output: output,
@@ -168,7 +171,6 @@ function run_compress_tests() {
                 });
                 return false;
             }
-            // expect == output
             try {
                 U.parse(output);
             } catch (ex) {
@@ -216,8 +218,9 @@ function run_compress_tests() {
                 }
                 stdout = sandbox.run_code(output);
                 if (!sandbox.same_stdout(test.expect_stdout, stdout)) {
-                    log("!!! failed\n---INPUT---\n{input}\n---EXPECTED {expected_type}---\n{expected}\n---ACTUAL {actual_type}---\n{actual}\n\n", {
+                    log("!!! failed\n---INPUT---\n{input}\n---OUTPUT---\n{output}\n---EXPECTED {expected_type}---\n{expected}\n---ACTUAL {actual_type}---\n{actual}\n\n", {
                         input: input_formatted,
+                        output: output,
                         expected_type: typeof test.expect_stdout == "string" ? "STDOUT" : "ERROR",
                         expected: test.expect_stdout,
                         actual_type: typeof stdout == "string" ? "STDOUT" : "ERROR",


### PR DESCRIPTION
Note: generated code may be suboptimal as optimizations not merged

* make test `expect`/`expect_exact` clauses optional when `expect_stdout` present