### PR TITLE
Fix inline source maps containing unicode characters

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -3,7 +3,7 @@
 var to_ascii = typeof atob == "undefined" ? function(b64) {
     if (Buffer.from && Buffer.from !== Uint8Array.from) {
       // Node >= 4.5.0
-      return Buffer.from(b64, "base64").toString("ascii");
+      return Buffer.from(b64, "base64").toString();
     } else {
       // Node < 4.5.0, old API, manual safeguards
       if (typeof b64 !== "string") throw new Errror("\"b64\" must be a string");
@@ -13,7 +13,7 @@ var to_ascii = typeof atob == "undefined" ? function(b64) {
 var to_base64 = typeof btoa == "undefined" ? function(str) {
     if (Buffer.from && Buffer.from !== Uint8Array.from) {
       // Node >= 4.5.0
-      return Buffer.from(str, "ascii").toString("base64");
+      return Buffer.from(str).toString("base64");
     } else {
       // Node < 4.5.0, old API, manual safeguards
       if (typeof str !== "string") throw new Errror("\"str\" must be a string");

--- a/test/sourcemaps.js
+++ b/test/sourcemaps.js
@@ -23,6 +23,21 @@ module.exports = function () {
     ].join("\n"));
 
     ok.deepEqual(issue836.names, ['enabled', 'x']);
+
+    // Test inline source maps with unicode characters
+    var with_inline_map = UglifyJS.minify([
+        "var tëst = '→unicøde←';",
+        "alert(tëst);",
+    ].join("\n"), {
+        sourceMap: { url: 'inline', includeSources: true }
+    }).code;
+    var unicode_result = UglifyJS.minify(with_inline_map, {
+        sourceMap: { content: 'inline', includeSources: true }
+    });
+    ok.ifError(unicode_result.error);
+    var unicode_map = JSON.parse(unicode_result.map);
+
+    ok.deepEqual(unicode_map.names, ['tëst', 'alert']);
 }
 
 function source_map(js) {


### PR DESCRIPTION
ae6f08ba294e2785aaf5ff9d4be4dd857fede147 added the `'ascii'` parameter
to Buffer conversion functions `to_ascii` and `to_base64`. However
`to_ascii` didn't actually convert to ascii before, but to a utf8 string
(the default Buffer.toString behaviour). Passing in 'ascii' breaks
reading and writing valid inline source maps with unicode characters.

This patch removes the 'ascii' parameter so that the conversion uses
utf8 again. I would've filed this upstream but it didn't get merged into
uglify-js yet (only uglify-es, and thus terser).

Ref https://github.com/mishoo/UglifyJS2/pull/2947