### PR TITLE
port uglify-js `arguments` compress option fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
   the resultant code is shorter: `m(){return x}` becomes `m:()=>x`.
   This transform requires that the `ecma` compress option is set to `6` or greater.
 
-- `arguments` (default: `true`) -- replace `arguments[index]` with function
+- `arguments` (default: `false`) -- replace `arguments[index]` with function
   parameter name whenever possible.
 
 - `booleans` (default: `true`) -- various optimizations for boolean context,

--- a/lib/compress.js
+++ b/lib/compress.js
@@ -49,7 +49,7 @@ function Compressor(options, false_by_default) {
     TreeTransformer.call(this, this.before, this.after);
     if (options.defaults !== undefined && !options.defaults) false_by_default = true;
     this.options = defaults(options, {
-        arguments     : !false_by_default,
+        arguments     : false,
         arrows        : !false_by_default,
         booleans      : !false_by_default,
         collapse_vars : !false_by_default,
@@ -532,14 +532,15 @@ merge(Compressor.prototype, {
             var sym = node.left;
             if (!(sym instanceof AST_SymbolRef)) return;
             var d = sym.definition();
+            var safe = safe_to_assign(tw, d, sym.scope, node.right);
+            d.assignments++;
+            if (!safe) return;
             var fixed = d.fixed;
             if (!fixed && node.operator != "=") return;
-            if (!safe_to_assign(tw, d, sym.scope, node.right)) return;
             var eq = node.operator == "=";
             var value = eq ? node.right : node;
             if (is_modified(compressor, tw, node, value, 0)) return;
             d.references.push(sym);
-            d.assignments++;
             if (!eq) d.chained = true;
             d.fixed = eq ? function() {
                 return node.right;
@@ -674,7 +675,7 @@ merge(Compressor.prototype, {
                 node.argnames.forEach(function(arg, i) {
                     if (!arg.definition) return;
                     var d = arg.definition();
-                    if (!node.uses_arguments && d.fixed === undefined) {
+                    if (d.fixed === undefined && (!node.uses_arguments || tw.has_directive("use strict"))) {
                         d.fixed = function() {
                             return iife.args[i] || make_node(AST_Undefined, iife);
                         };
@@ -766,13 +767,15 @@ merge(Compressor.prototype, {
         def(AST_Unary, function(tw, descend) {
             var node = this;
             if (node.operator != "++" && node.operator != "--") return;
-            if (!(node.expression instanceof AST_SymbolRef)) return;
-            var d = node.expression.definition();
+            var exp = node.expression;
+            if (!(exp instanceof AST_SymbolRef)) return;
+            var d = exp.definition();
+            var safe = safe_to_assign(tw, d, true);
+            d.assignments++;
+            if (!safe) return;
             var fixed = d.fixed;
             if (!fixed) return;
-            if (!safe_to_assign(tw, d, true)) return;
-            d.references.push(node.expression);
-            d.assignments++;
+            d.references.push(exp);
             d.chained = true;
             d.fixed = function() {
                 return make_node(AST_Binary, node, {
@@ -3294,6 +3297,16 @@ merge(Compressor.prototype, {
         // this scope (not in nested scopes).
         var scope = this;
         var tw = new TreeWalker(function(node, descend){
+            if (node instanceof AST_Lambda && node.uses_arguments && !tw.has_directive("use strict")) {
+                node.argnames.forEach(function(argname) {
+                    if (argname instanceof AST_Destructuring) return;
+                    var def = argname.definition();
+                    if (!(def.id in in_use_ids)) {
+                        in_use_ids[def.id] = true;
+                        in_use.push(def);
+                    }
+                });
+            }
             if (node === self) return;
             if (node instanceof AST_Defun || node instanceof AST_DefClass) {
                 var node_def = node.name.definition();
@@ -3389,8 +3402,7 @@ merge(Compressor.prototype, {
                     // any declarations with same name will overshadow
                     // name of this anonymous function and can therefore
                     // never be used anywhere
-                    if (!(def.id in in_use_ids) || def.orig.length > 1)
-                        node.name = null;
+                    if (!(def.id in in_use_ids) || def.orig.length > 1) node.name = null;
                 }
                 if (node instanceof AST_Lambda && !(node instanceof AST_Accessor)) {
                     var trim = !compressor.option("keep_fargs");
@@ -3413,8 +3425,7 @@ merge(Compressor.prototype, {
                                 a.pop();
                                 compressor[sym.unreferenced() ? "warn" : "info"]("Dropping unused function argument {name} [{file}:{line},{col}]", template(sym));
                             }
-                        }
-                        else {
+                        } else {
                             trim = false;
                         }
                     }
@@ -6250,6 +6261,51 @@ merge(Compressor.prototype, {
                 }
             }
         }
+        var fn;
+        OPT_ARGUMENTS: if (compressor.option("arguments")
+            && expr instanceof AST_SymbolRef
+            && expr.name == "arguments"
+            && expr.definition().orig.length == 1
+            && (fn = expr.scope) instanceof AST_Lambda
+            && fn.uses_arguments
+            && !(fn instanceof AST_Arrow)
+            && prop instanceof AST_Number) {
+            var index = prop.getValue();
+            var params = Object.create(null);
+            var argnames = fn.argnames;
+            for (var n = 0; n < argnames.length; n++) {
+                if (!(argnames[n] instanceof AST_SymbolFunarg)) {
+                    break OPT_ARGUMENTS; // destructuring parameter - bail
+                }
+                var param = argnames[n].name;
+                if (param in params) {
+                    break OPT_ARGUMENTS; // duplicate parameter - bail
+                }
+                params[param] = true;
+            }
+            var argname = fn.argnames[index];
+            if (argname && compressor.has_directive("use strict")) {
+                var def = argname.definition();
+                if (!compressor.option("reduce_vars") || def.assignments || def.orig.length > 1) {
+                    argname = null;
+                }
+            } else if (!argname && !compressor.option("keep_fargs") && index < fn.argnames.length + 5) {
+                while (index >= fn.argnames.length) {
+                    argname = make_node(AST_SymbolFunarg, fn, {
+                        name: fn.make_var_name("argument_" + fn.argnames.length),
+                        scope: fn
+                    });
+                    fn.argnames.push(argname);
+                    fn.enclosed.push(fn.def_variable(argname));
+                }
+            }
+            if (argname) {
+                var sym = make_node(AST_SymbolRef, self, argname);
+                sym.reference({});
+                delete argname.__unused;
+                return sym;
+            }
+        }
         if (is_lhs(self, compressor.parent())) return self;
         if (key !== prop) {
             var sub = self.flatten_object(property, compressor);
@@ -6294,32 +6350,6 @@ merge(Compressor.prototype, {
                         value: index
                     })
                 });
-            }
-        }
-        var fn;
-        if (compressor.option("arguments")
-            && expr instanceof AST_SymbolRef
-            && expr.name == "arguments"
-            && expr.definition().orig.length == 1
-            && (fn = expr.scope) instanceof AST_Lambda
-            && !(fn instanceof AST_Arrow)
-            && prop instanceof AST_Number) {
-            var index = prop.getValue();
-            var argname = fn.argnames[index];
-            if (!argname && !compressor.option("keep_fargs")) {
-                while (index >= fn.argnames.length) {
-                    argname = make_node(AST_SymbolFunarg, fn, {
-                        name: fn.make_var_name("argument_" + fn.argnames.length),
-                        scope: fn
-                    });
-                    fn.argnames.push(argname);
-                    fn.enclosed.push(fn.def_variable(argname));
-                }
-            }
-            if (argname) {
-                var sym = make_node(AST_SymbolRef, self, argname);
-                sym.reference({});
-                return sym;
             }
         }
         var ev = self.evaluate(compressor);

--- a/test/compress/drop-unused.js
+++ b/test/compress/drop-unused.js
@@ -2292,3 +2292,31 @@ issue_3146_4: {
     }
     expect_stdout: "PASS"
 }
+
+issue_3192: {
+    options = {
+        unused: true,
+    }
+    input: {
+        (function(a) {
+            console.log(a = "foo", arguments[0]);
+        })("bar");
+        (function(a) {
+            "use strict";
+            console.log(a = "foo", arguments[0]);
+        })("bar");
+    }
+    expect: {
+        (function(a) {
+            console.log(a = "foo", arguments[0]);
+        })("bar");
+        (function(a) {
+            "use strict";
+            console.log("foo", arguments[0]);
+        })("bar");
+    }
+    expect_stdout: [
+        "foo foo",
+        "foo bar",
+    ]
+}

--- a/test/ufuzz.json
+++ b/test/ufuzz.json
@@ -27,6 +27,7 @@
     },
     {
         "compress": {
+            "arguments": true,
             "keep_fargs": false,
             "passes": 1e6,
             "sequences": 1e6,


### PR DESCRIPTION
https://github.com/mishoo/UglifyJS2/pull/3193

also take into account:
  - parameter destructuring
  - duplicate parameter names

disable compress option `arguments` by default

fixes #58