### PR TITLE
generate source map for browser bundle upon prepublish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /npm-debug.log
 tmp/
 dist/browser.bundle.js
+dist/browser.bundle.js.map

--- a/bin/uglifyjs
+++ b/bin/uglifyjs
@@ -3,13 +3,25 @@
 
 "use strict";
 
-require("../tools/exit");
+require("../tools/exit.js");
 
 var fs = require("fs");
 var info = require("../package.json");
 var path = require("path");
 var program = require("commander");
-var UglifyJS = require("../tools/node");
+
+var bundle_path = __dirname + "/../dist/browser.bundle.js";
+if (process.env.TERSER_DEBUG
+    /* note: commander not initialized yet */
+    && !/--help|--self/.test(process.argv.toString())
+    && fs.existsSync(bundle_path)) {
+    var UglifyJS = require(bundle_path);
+    try {
+        require("source-map-support").install();
+    } catch (err) {}
+} else {
+    var UglifyJS = require("../tools/node.js");
+}
 
 var skip_keys = [ "cname", "inlined", "parent_scope", "scope", "uses_eval", "uses_with" ];
 var files = {};
@@ -50,7 +62,7 @@ program.option("--name-cache <file>", "File to hold mangled name mappings.");
 program.option("--rename", "Force symbol expansion.");
 program.option("--no-rename", "Disable symbol expansion.");
 program.option("--safari10", "Support non-standard Safari 10.");
-program.option("--self", "Build UglifyJS as a library (implies --wrap UglifyJS)");
+program.option("--self", "Build Terser as a library (implies --wrap Terser)");
 program.option("--source-map [options]", "Enable source map/specify source map options.", parse_source_map());
 program.option("--timings", "Display operations run time on STDERR.");
 program.option("--toplevel", "Compress and/or mangle variables in toplevel scope.");
@@ -112,7 +124,7 @@ if (program.mangleProps) {
     } else {
         if (typeof program.mangleProps != "object") program.mangleProps = {};
         if (!Array.isArray(program.mangleProps.reserved)) program.mangleProps.reserved = [];
-        require("../tools/domprops").forEach(function(name) {
+        require("../tools/domprops.json").forEach(function(name) {
             UglifyJS._push_uniq(program.mangleProps.reserved, name);
         });
     }

--- a/lib/output.js
+++ b/lib/output.js
@@ -233,7 +233,7 @@ function OutputStream(options) {
                     !mapping.name && mapping.token.type == "name" ? mapping.token.value : mapping.name
                 );
             } catch(ex) {
-                AST_Node.warn("Couldn't figure out mapping for {file}:{line},{col} → {cline},{ccol} [{name}]", {
+                mapping.token.file != null && AST_Node.warn("Couldn't figure out mapping for {file}:{line},{col} → {cline},{ccol} [{name}]", {
                     file: mapping.token.file,
                     line: mapping.token.line,
                     col: mapping.token.col,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1258,6 +1258,15 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
+    "source-map-support": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+      "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "spawn-sync": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   ],
   "dependencies": {
     "commander": "~2.14.1",
-    "source-map": "~0.6.1"
+    "source-map": "~0.6.1",
+    "source-map-support": "~0.5.6"
   },
   "devDependencies": {
     "acorn": "~5.4.1",
@@ -42,7 +43,7 @@
     "test": "node test/run-tests.js",
     "lint": "eslint lib",
     "lint-fix": "eslint --fix lib",
-    "prepublish": "node bin/uglifyjs --self -d \"MOZ_SourceMap=require('source-map')\" -e Terser:module.exports --beautify -o dist/browser.bundle.js"
+    "prepublish": "node bin/uglifyjs lib/utils.js lib/ast.js lib/parse.js lib/transform.js lib/scope.js lib/output.js lib/compress.js lib/sourcemap.js lib/mozilla-ast.js lib/propmangle.js lib/minify.js tools/exports.js -c defaults=false -d \"MOZ_SourceMap=require('source-map')\" --source-map \"includeSources=true,url='browser.bundle.js.map'\" -e \"exports:(typeof module != 'undefined' ? module.exports : Terser = {})\" -b ascii_only --comments /license/ -o dist/browser.bundle.js"
   },
   "keywords": [
     "uglify",


### PR DESCRIPTION
- browser bundle works with JS bundlers as well as with
  an HTML <script> tag using the global `Terser` variable.

- enable source map debug support for CLI with
  TERSER_DEBUG=1 environment variable setting.