### PR TITLE
Fix documentation bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,6 @@ If you're using the `X-SourceMap` header instead, you can just omit `sourceMap.u
 - `arrows` (default: `true`) -- Converts `()=>{return x}` to `()=>x`. Class
   and object literal methods will also be converted to arrow expressions if
   the resultant code is shorter: `m(){return x}` becomes `m:()=>x`.
-  This transform requires that the `ecma` compress option is set to `6` or greater.
 
 - `arguments` (default: `false`) -- replace `arguments[index]` with function
   parameter name whenever possible.


### PR DESCRIPTION
fixes: https://github.com/mishoo/UglifyJS2/issues/3248

This PR removes the wrong explanation of the `arrows` compress option.

> Since shorthand methods are only valid in ES6+, it's a safe transform to replace with an arrow in this case regardless of the ecma setting. That ecma 6 comment was only intended for unsafe_arrows where it is applicable:
https://github.com/mishoo/UglifyJS2/issues/3248#issuecomment-418411148